### PR TITLE
Fix progress not ending when response is empty

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -123,7 +123,7 @@ function loadProgressBar(config) {
 
   var setupUpdateProgress = function setupUpdateProgress() {
     var update = function update(e) {
-      return _nprogress2.default.inc(calculatePercentage(e.loaded, e.total));
+      return _nprogress2.default.inc(calculatePercentage(e.loaded, e.total) || 1);
     };
     instance.defaults.onDownloadProgress = update;
     instance.defaults.onUploadProgress = update;

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ export function loadProgressBar (config, instance = axios) {
   }
 
   const setupUpdateProgress = () => {
-    const update = e => NProgress.inc(calculatePercentage(e.loaded, e.total))
+    const update = e => NProgress.inc(calculatePercentage(e.loaded, e.total) || 1)
     instance.defaults.onDownloadProgress = update
     instance.defaults.onUploadProgress = update
   }


### PR DESCRIPTION
When response data is empty, the request 'loaded' and 'total' values are
0, making calculatePercentage return NaN.

When nProgress receives that value, it accepts as a 'number' and brakes
itself, preventing 'done()' from working.

Fixes #13